### PR TITLE
Fix headline splitting error

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,7 @@
       </div>
 
       <div class="field">
-        <label for="headline">Headline phrase (negative space, supports 
-)</label>
+        <label for="headline">Headline phrase (negative space, supports line breaks)</label>
         <textarea id="headline">REAL WAGES STUCK IN 2008</textarea>
       </div>
 
@@ -249,8 +248,7 @@
       let phrase = els.bgPhrase.value.trim(); let head = els.headline.value.trim();
       if (els.caps.checked){ phrase = phrase.toUpperCase(); head = head.toUpperCase(); }
 
-      const lines = head.split(/
-/);
+        const lines = head.split(/\n/);
       const margin = Math.max(0, parseInt(els.margin.value, 10) || 80);
       const maxHeadPx = Math.max(24, parseInt(els.headlineSize.value, 10) || 260);
       const { sample: maskHit } = buildHeadlineMask(w, h, lines, margin, maxHeadPx, els.autoFit.checked);


### PR DESCRIPTION
## Summary
- Ensure headline text is split on newlines correctly
- Clarify headline field label

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fc4b5920c83329c01215e888069e1