### PR TITLE
Randomize fade-out letter removal

### DIFF
--- a/fine_fade.py
+++ b/fine_fade.py
@@ -1,31 +1,43 @@
 import random
 from typing import List
 
-def fine_fade(phrase: str = "EVERYTHING IS FINE", rows: int = 6, width: int = 40, seed: int | None = None) -> List[str]:
+def fine_fade(
+    phrase: str = "EVERYTHING IS FINE",
+    rows: int = 6,
+    width: int = 40,
+    seed: int | None = None,
+) -> List[str]:
     """Return rows of text fading to a spaced "F I N E".
 
-    Characters from the start of the phrase disappear row by row while the
-    gaps between remaining characters become increasingly random. The final
-    row spreads the letters ``F`` ``I`` ``N`` ``E`` evenly across ``width``.
+    Letters disappear from random positions as the lines progress downward and
+    the gaps between remaining characters widen. The final row spreads the
+    letters ``F`` ``I`` ``N`` ``E`` evenly across ``width``.
     """
+
     rng = random.Random(seed)
-    letters = list(phrase.replace(" ", ""))
+    remaining = list(phrase.replace(" ", ""))
     lines: List[str] = []
 
     for row in range(rows - 1):
-        start = min(row, len(letters) - 4)
-        remain = letters[start:]
         max_gap = row + 1
-        parts = []
-        for i, ch in enumerate(remain):
+        parts: List[str] = []
+        for i, ch in enumerate(remaining):
             parts.append(ch)
-            if i < len(remain) - 1:
+            if i < len(remaining) - 1:
                 parts.append(" " * rng.randint(0, max_gap))
         lines.append("".join(parts))
 
+        # Remove a random character for the next row, but always leave at
+        # least four so that the final "FINE" row stands out.
+        if len(remaining) > 4:
+            del remaining[rng.randrange(len(remaining))]
+
     # Final row: letters F I N E evenly spaced across the width
     letters_final = list("FINE")
-    positions = [int(i * (width - 1) / (len(letters_final) - 1)) for i in range(len(letters_final))]
+    positions = [
+        int(i * (width - 1) / (len(letters_final) - 1))
+        for i in range(len(letters_final))
+    ]
     row_chars = [" "] * width
     for pos, ch in zip(positions, letters_final):
         row_chars[pos] = ch


### PR DESCRIPTION
## Summary
- Randomize character removal to create a more organic fade-out effect.
- Widen spacing between remaining letters and maintain a final evenly spaced "FINE" row.

## Testing
- `python3 -m py_compile fine_fade.py`
- `python3 fine_fade.py`


------
https://chatgpt.com/codex/tasks/task_e_689fd5c7c5988332817deb738f5bb85a