### PR TITLE
Improve fine fade to remove letters without widening gaps

### DIFF
--- a/fine_fade.py
+++ b/fine_fade.py
@@ -9,9 +9,11 @@ def fine_fade(
 ) -> List[str]:
     """Return rows of text fading to a spaced "F I N E".
 
-    Letters disappear from random positions as the lines progress downward and
-    the gaps between remaining characters widen. The final row spreads the
-    letters ``F`` ``I`` ``N`` ``E`` evenly across ``width``.
+    Letters disappear from random positions as the lines progress downward.
+    Each line shows the remaining characters separated by single spaces and
+    removes an increasing number of letters so that text contracts rather than
+    leaving growing gaps. The final row spreads the letters ``F`` ``I`` ``N``
+    ``E`` evenly across ``width``.
     """
 
     rng = random.Random(seed)
@@ -19,18 +21,14 @@ def fine_fade(
     lines: List[str] = []
 
     for row in range(rows - 1):
-        max_gap = row + 1
-        parts: List[str] = []
-        for i, ch in enumerate(remaining):
-            parts.append(ch)
-            if i < len(remaining) - 1:
-                parts.append(" " * rng.randint(0, max_gap))
-        lines.append("".join(parts))
+        lines.append(" ".join(remaining))
 
-        # Remove a random character for the next row, but always leave at
-        # least four so that the final "FINE" row stands out.
-        if len(remaining) > 4:
-            del remaining[rng.randrange(len(remaining))]
+        # Remove more letters as we progress downwards, but ensure at least
+        # four characters remain for the final "FINE" line.
+        remove_count = min(row + 1, len(remaining) - 4)
+        for _ in range(remove_count):
+            if len(remaining) > 4:
+                del remaining[rng.randrange(len(remaining))]
 
     # Final row: letters F I N E evenly spaced across the width
     letters_final = list("FINE")


### PR DESCRIPTION
## Summary
- shrink fading text by deleting characters each row instead of inserting larger spaces
- document new fade behaviour and keep final F I N E spacing

## Testing
- `python fine_fade.py`
- `python -m py_compile fine_fade.py`


------
https://chatgpt.com/codex/tasks/task_e_68a04a763fa88332b2399be1ed310cbb