### PR TITLE
Use ease-in easing for row fade

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,7 +311,7 @@
       const spreadFactor = Math.max(0, parseFloat(els.spreadFactor.value) || 0);
       const rowsInSpread = Math.min(spreadRows, totalRows);
       const startSpreadRow = Math.max(0, totalRows - rowsInSpread);
-      const easeOut = t => 1 - Math.pow(1 - t, 3);
+      const easeIn = t => t * t;
 
       let rowIndex = 0;
       for (let y = 0; y < h + rowH; y += rowH, rowIndex++){
@@ -324,7 +324,7 @@
             ? 1
             : (rowIndex - startSpreadRow) / (rowsInSpread - 1);
         }
-        const progress = easeOut(Math.min(1, Math.max(0, t)));
+        const progress = easeIn(Math.min(1, Math.max(0, t)));
         const spreadMul = 1 + spreadFactor * progress;
         const dropProb = progress;
 


### PR DESCRIPTION
## Summary
- Use an ease-in curve when calculating spread progress so early rows keep more letters

## Testing
- `python -m py_compile fine_fade.py`
- `node - <<'NODE'
const easeIn = t => t*t;
console.log([0,0.25,0.5,0.75,1].map(easeIn));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a0c3c691208332b9d187fc3b2230d0